### PR TITLE
remove unnecessary ternary operators from eww configs

### DIFF
--- a/.config/eww/modules/control_center.yuck
+++ b/.config/eww/modules/control_center.yuck
@@ -1,5 +1,5 @@
 (defwidget control_center []
-    (revealer :transition "slideleft" :reveal {open_control_center == true ? true : false} :duration {ANIM_DURATION}
+    (revealer :transition "slideleft" :reveal {open_control_center} :duration {ANIM_DURATION}
         (box :orientation "v" :space-evenly false
             (music)
             (notifications)

--- a/.config/eww/modules/launcher.yuck
+++ b/.config/eww/modules/launcher.yuck
@@ -8,7 +8,7 @@
 )
 
 (defwidget launcher []
-    (revealer :transition "slideright" :reveal {open_launcher == true ? true : false} :duration {ANIM_DURATION}
+    (revealer :transition "slideright" :reveal {open_launcher} :duration {ANIM_DURATION}
         (eventbox :onclick "scripts/toggle_launcher.sh close &"
             (box :orientation "v" :space-evenly false :class "launcher-box"
                 (box :orientation "h" :space-evenly false :class "launcher-search"

--- a/.config/eww/modules/tray.yuck
+++ b/.config/eww/modules/tray.yuck
@@ -1,5 +1,5 @@
 (defwidget tray []
-    (revealer :transition "slideup" :reveal {open_tray == true ? true : false} :duration {ANIM_DURATION}
+    (revealer :transition "slideup" :reveal {open_tray} :duration {ANIM_DURATION}
         (box :class "tray_box" :orientation "h" :space-evenly false
             (systray :hexpand true :halign "center" :pack-direction "left")
         )

--- a/.config/eww/modules/volume.yuck
+++ b/.config/eww/modules/volume.yuck
@@ -1,5 +1,5 @@
 (defwidget volume_osd []
-    (revealer :transition "slideup" :reveal {open_osd == true ? true : false} :duration {ANIM_DURATION}
+    (revealer :transition "slideup" :reveal {open_osd} :duration {ANIM_DURATION}
         (box :orientation "h" :class "volume-osd" :space-evenly false
             (volume_scale)
         )


### PR DESCRIPTION
I have noticed that some files (control_center.yuck, volume.yuck, launcher.yuck and tray.yuck) contain unnecessary ternary operators that could be removed for readability.

This pull request just changes those ternary operators with just the variable like this:
`{open_osd == true ? true : false}` → `{open_osd}`