### PR TITLE
feat: add VPN menu

### DIFF
--- a/ignis/modules/control_center/quick_settings.py
+++ b/ignis/modules/control_center/quick_settings.py
@@ -4,6 +4,7 @@ from .record import record_control
 from .dnd import dnd_button
 from .dark_mode import dark_mode_button
 from .ethernet import ethernet_control
+from .vpn import vpn_control
 from .qs_button import QSButton
 from ignis.services.network import NetworkService
 
@@ -42,6 +43,7 @@ def qs_config(main_box: Widget.Box) -> None:
         main_box,
         *wifi_control(),
         *ethernet_control(),
+        *vpn_control(),
         dnd_button(),
         dark_mode_button(),
         record_control(),

--- a/ignis/modules/control_center/vpn.py
+++ b/ignis/modules/control_center/vpn.py
@@ -17,7 +17,7 @@ class VpnNetworkItem(Widget.Button):
             child=Widget.Box(
                 child=[
                     Widget.Label(
-                        label=conn.get_id,
+                        label=conn.connection_id,
                         ellipsize="end",
                         max_width_chars=20,
                         halign="start",

--- a/ignis/modules/control_center/vpn.py
+++ b/ignis/modules/control_center/vpn.py
@@ -1,0 +1,117 @@
+from ignis.widgets import Widget
+from ignis.utils import Utils
+from .qs_button import QSButton
+from typing import List
+from ignis.services.network import NetworkService, VpnConnection
+
+
+network = NetworkService.get_default()
+
+
+class VpnNetworkItem(Widget.Button):
+    def __init__(self, conn: VpnConnection):
+
+        super().__init__(
+            css_classes=["vpn-connection-item", "unset"],
+            on_click=lambda x: conn.toggle_connection(),
+            child=Widget.Box(
+                child=[
+                    Widget.Label(
+                        label=conn.get_id,
+                        ellipsize="end",
+                        max_width_chars=20,
+                        halign="start",
+                        css_classes=["vpn-connection-label"],
+                    ),
+                    Widget.Button(
+                        child=Widget.Label(
+                            label=conn.bind(
+                                "is_connected",
+                                lambda value: "Disconnect" if value else "Connect",
+                            )
+                        ),
+                        css_classes=["vpn-connection-item-connect-label", "unset"],
+                        halign="end",
+                        hexpand=True,
+                    ),
+                ]
+            ),
+        )
+
+
+def vpn_qsbutton() -> QSButton:
+    networks_list = Widget.Revealer(
+        transition_duration=300,
+        transition_type="slide_down",
+        child=Widget.Box(
+            vertical=True,
+            css_classes=["vpn-connection-list"],
+            child=[
+                Widget.Box(
+                    css_classes=["vpn-header-box"],
+                    child=[
+                        Widget.Icon(
+                            icon_name="network-vpn-symbolic", pixel_size=28),
+                        Widget.Label(
+                            label="VPN connections",
+                            css_classes=["vpn-header-label"],
+                        ),
+                    ],
+                ),
+                Widget.Box(
+                    vertical=True,
+                    child=network.vpn.bind(
+                        "connections",
+                        transform=lambda value: [
+                            VpnNetworkItem(i) for i in value],
+                    ),
+                ),
+                Widget.Separator(
+                    css_classes=["vpn-connection-list-separator"]),
+                Widget.Button(
+                    css_classes=["vpn-connection-item", "unset"],
+                    on_click=lambda x: Utils.exec_sh_async(
+                        "nm-connection-editor"),
+                    style="margin-bottom: 0;",
+                    child=Widget.Box(
+                        child=[
+                            Widget.Icon(image="preferences-system-symbolic"),
+                            Widget.Label(
+                                label="Network Manager",
+                                halign="start",
+                                css_classes=["vpn-connection-label"],
+                            ),
+                        ]
+                    ),
+                ),
+            ],
+        ),
+    )
+
+    def get_label(id: str) -> str:
+        if id:
+            return id
+        else:
+            return "VPN"
+
+    def get_icon(icon_name: str) -> str:
+        if network.vpn.is_connected:
+            return icon_name
+        else:
+            return "network-vpn-symbolic"
+
+    def toggle_list(x) -> None:
+        networks_list.toggle()
+
+    return QSButton(
+        label=network.vpn.bind("active_vpn_id", get_label),
+        icon_name=network.vpn.bind("icon-name", get_icon),
+        on_activate=toggle_list,
+        on_deactivate=toggle_list,
+        active=network.vpn.bind("is-connected"),
+        content=networks_list,
+    )
+
+
+def vpn_control() -> List[QSButton]:
+    return [vpn_qsbutton()]

--- a/ignis/modules/control_center/vpn.py
+++ b/ignis/modules/control_center/vpn.py
@@ -17,7 +17,7 @@ class VpnNetworkItem(Widget.Button):
             child=Widget.Box(
                 child=[
                     Widget.Label(
-                        label=conn.connection_id,
+                        label=conn.name,
                         ellipsize="end",
                         max_width_chars=20,
                         halign="start",

--- a/ignis/scss/control_center.scss
+++ b/ignis/scss/control_center.scss
@@ -184,7 +184,8 @@
 }
 
 .ethernet-network-list,
-.wifi-network-list {
+.wifi-network-list,
+.vpn-connection-list {
     background-color: $surfaceContainerHigh;
     border-radius: 1rem;
     padding: 1rem;
@@ -193,16 +194,19 @@
 }
 
 .ethernet-network-list-separator,
-.wifi-network-list-separator {
+.wifi-network-list-separator,
+.vpn-connection-list-separator,{
     margin: 0.5rem 0;
 }
 
 .ethernet-header-box,
-.wifi-header-box {
+.wifi-header-box 
+.vpn-header-box {
     margin-bottom: 0.5rem;
 }
 
-.ethernet-header-label {
+.ethernet-header-label 
+.vpn-header-label {
     font-size: 1.35rem;
     margin-left: 0.75rem;
 }
@@ -212,7 +216,8 @@
 }
 
 .ethernet-connection-item,
-.wifi-network-item {
+.wifi-network-item,
+.vpn-connection-item {
     @include hover($surfaceContainerHigh);
     transition: 0.3s;
     border-radius: 1rem;
@@ -221,11 +226,13 @@
 
 
 .ethernet-connection-label,
-.wifi-network-label {
+.wifi-network-label 
+.vpn-connection-label {
     margin-left: 0.5rem;
 }
 
-.ethernet-connection-item-connect-label {
+.ethernet-connection-item-connect-label 
+.vpn-connection-item-connect-label {
     color: $onSurfaceVariant;
     font-size: 1rem;
 }


### PR DESCRIPTION
The following is a configuration of vpn functionality into a style-abiding menu, underlying functionality provided in ignis [PR](https://github.com/linkfrg/ignis/pull/29) must be merged beforehand.