### PR TITLE
Add wl-clipboard dependency

### DIFF
--- a/dependencies.txt
+++ b/dependencies.txt
@@ -39,3 +39,4 @@ ttf-jetbrains-mono-nerd
 ttf-nerd-fonts-symbols
 papirus-icon-theme
 upower
+wl-clipboard


### PR DESCRIPTION
Adds wl-clipboard to `dependencies.txt`, otherwise grimblast will be unable to copy to clipboard.